### PR TITLE
Convert updater.py to python3

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -2,31 +2,36 @@ import serial
 from optparse import OptionParser
 from time import sleep
 
+
 def waitForChar(ser, c):
     recv_char = ser.read()
     while recv_char not in c:
         recv_char = ser.read()
     return recv_char
-                
+
+
 def calcStmCrc(data, idx, len):
     cnt = 0
     crc = 0xffffffff
-    
+
     while cnt < len:
-        word = data[idx] | (data[idx+1] << 8) | (data[idx+2] << 16) | (data[idx+3] << 24)
+        word = data[idx] | (data[idx+1] << 8) | (data[idx+2]
+                                                 << 16) | (data[idx+3] << 24)
         cnt = cnt + 4
         idx = idx + 4
-        
+
         crc = crc ^ word
-        
-        for i in range(0,32):
+
+        for i in range(0, 32):
             if crc & 0x80000000:
-                crc = ((crc << 1) ^ 0x04C11DB7) & 0xffffffff; # Polynomial used in STM32
+                # Polynomial used in STM32
+                crc = ((crc << 1) ^ 0x04C11DB7) & 0xffffffff
             else:
-                crc = (crc << 1) & 0xffffffff;
+                crc = (crc << 1) & 0xffffffff
     return crc
 
-PAGE_SIZE_BYTES=1024
+
+PAGE_SIZE_BYTES = 1024
 
 
 parser = OptionParser()
@@ -46,31 +51,31 @@ if not options.device:   # if device is not given
 ser = serial.Serial(options.device, 115200, timeout=2, stopbits=2)
 
 updateFile = open(options.filename, "rb")
-data = bytearray(updateFile.read());
+data = bytearray(updateFile.read())
 updateFile.close()
 
 numBytes = len(data)
-numPages = (numBytes + PAGE_SIZE_BYTES - 1) / PAGE_SIZE_BYTES
+numPages = (numBytes + PAGE_SIZE_BYTES - 1) // PAGE_SIZE_BYTES
 
 while (len(data) % PAGE_SIZE_BYTES) > 0:
     data.append(0)
 
-print "File length is %d bytes/%d pages" % (numBytes, numPages)
-print "Resetting device..."
+print("File length is %d bytes/%d pages" % (numBytes, numPages))
+print("Resetting device...")
 
-ser.write("reset\r")
-version = waitForChar(ser, "S2")
+ser.write(b'reset\r')
+version = waitForChar(ser, b'S2')
 
-if version == "2":
-	print "Version 2 bootloader, sending magic"
-	ser.write(chr(0xAA))
-	waitForChar(ser, "S")
+if version == b'2':
+    print("Version 2 bootloader, sending magic")
+    ser.write(b'\xAA')
+    waitForChar(ser, b'S')
 
-print "Sending number of pages..."
+print("Sending number of pages...")
 
-ser.write(chr(numPages))
+ser.write([numPages])
 
-waitForChar(ser, "P")
+waitForChar(ser, b'P')
 
 done = False
 page = 0
@@ -79,38 +84,38 @@ idx = 0
 while not done:
     crc = calcStmCrc(data, idx, PAGE_SIZE_BYTES)
     c = 0
-    
-    while c != "P" and not done:
-        print "Sending page %d..." % (page),
+
+    while c != b'P' and not done:
+        print("Sending page %d..." % (page), end=' ')
         idx = page * PAGE_SIZE_BYTES
         cnt = 0
-        
+
         while cnt < PAGE_SIZE_BYTES:
-            ser.write(chr(data[idx]))
+            ser.write([data[idx]])
             idx = idx + 1
             cnt = cnt + 1
-        
+
         c = ser.read()
-        
-        if "C" == c:
-            ser.write(chr(crc & 0xFF))
-            ser.write(chr((crc >> 8) & 0xFF))
-            ser.write(chr((crc >> 16) & 0xFF))
-            ser.write(chr((crc >> 24) & 0xFF))
-        
+
+        if b'C' == c:
+            ser.write([crc & 0xFF])
+            ser.write([(crc >> 8) & 0xFF])
+            ser.write([(crc >> 16) & 0xFF])
+            ser.write([(crc >> 24) & 0xFF])
+
             c = ser.read()
-    
-        if 'D' == c:
-            print "CRC correct!"
-            print "Update done!"
-            done = True;
-        elif 'E' == c:
-            print "CRC error!"
-            waitForChar(ser, "T")
-        elif 'P' == c:
-            print "CRC correct!"
-            page = page + 1;
-        elif 'T' == c:
-            print "Sync Error!"
+
+        if b'D' == c:
+            print("CRC correct!")
+            print("Update done!")
+            done = True
+        elif b'E' == c:
+            print("CRC error!")
+            waitForChar(ser, b'T')
+        elif b'P' == c:
+            print("CRC correct!")
+            page = page + 1
+        elif b'T' == c:
+            print("Sync Error!")
         else:
-            print c
+            print(c)


### PR DESCRIPTION
With the retirement of python2 this updates the updater.py
script to python3. The main changes are:
 - Convert print to print()
 - Change floating point division (/) to integer floor division (//)
   when calculating number of pages
 - Characters are now unicode so change all constants sent to
   the serial port to byte type b'x'
 - Values sent to the serial port now enclosed in [] to convert
   to bytes type. This seemed neater than adding .to_bytes()
   which is an alternative.
 - Auto-format using autopep8

Tests:
 - Update stm32_sine code with an openocd flashed
   stm32_bootloader
 - Replace entire firmware with bootupdater.bin,
   stm32_bootloader.bin and stm32_sine.bin and verify
   correct installation